### PR TITLE
Update hypersonic.json - Removed Record

### DIFF
--- a/data/hypersonic.json
+++ b/data/hypersonic.json
@@ -2266,12 +2266,6 @@
 			"hz": 360
 		},
 		{
-			"user": "[POT] AbysmalGD",
-			"link": "https://www.youtube.com/watch?v=yXi25BsN_gw",
-			"percent": 100,
-			"hz": 360
-		},
-		{
 			"user": "RegainedORU",
 			"link": "https://www.youtube.com/watch?v=AUTSLAH2hVM&t=15s",
 			"percent": 100,


### PR DESCRIPTION
Abysmal gd did not beat hypersonic, pancakeknight beat it with his icons and jokingly had him upload it to his account, he already submitted the completion under his name a while ago, but then abysmal uploaded it later to get extra points, even though it is not actually him playing.